### PR TITLE
Added shim for kubectl-gardenlogin to generation script

### DIFF
--- a/.github/workflows/choco-package.yml
+++ b/.github/workflows/choco-package.yml
@@ -9,7 +9,7 @@ jobs:
           - name: Event Information
             run: |
               echo "Event '${{ github.event.action }}' payload '${{ github.event.client_payload.tag }}'"
-              echo "Windows gardenlogin binary hash '${{ github.event.client_payload.windows_sha }}'"
+              echo "Windows binary hash '${{ github.event.client_payload.windows_sha }}'"
           - name: Get Version
             id: get_version
             run: |

--- a/.github/workflows/choco-package.yml
+++ b/.github/workflows/choco-package.yml
@@ -38,6 +38,7 @@ jobs:
           git config --local user.name "gardener-robot-ci-1"
           git add "gardenlogin\gardenlogin.${{ needs.package-push-common.outputs.version }}.nupkg"
           git add "gardenlogin\tools\chocolateyinstall.ps1"
+          git add "gardenlogin\tools\chocolateyuninstall.ps1"
           git commit -m "Update gardenlogin"
       - name: Push changes
         uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # pin@v0.6.0

--- a/.github/workflows/choco-package.yml
+++ b/.github/workflows/choco-package.yml
@@ -1,36 +1,42 @@
 name: Remote Dispatch Action
 on: [repository_dispatch]
 jobs:
+  package-push-common:
+      runs-on: windows-latest
+      outputs:
+        version: ${{ steps.get_version.outputs.version }}
+      steps:
+          - name: Event Information
+            run: |
+              echo "Event '${{ github.event.action }}' payload '${{ github.event.client_payload.tag }}'"
+              echo "Windows gardenlogin binary hash '${{ github.event.client_payload.windows_sha }}'"
+          - name: Get Version
+            id: get_version
+            run: |
+              $version="${{ github.event.client_payload.tag }}"
+              $version=$version.replace('v','')
+              echo "::set-output name=version::$version"
   package-push-gardenlogin:
     if: github.event.client_payload.component == 'gardenlogin'
     runs-on: windows-latest
+    needs: package-push-common
     steps:
-      - name: Event Information
-        run: |
-          echo "Event '${{ github.event.action }}' payload '${{ github.event.client_payload.tag }}'"
-          echo "Windows gardenlogin binary hash '${{ github.event.client_payload.windows_sha }}'"
-      - name: Get Version
-        id: get_version
-        run: |
-          $version="${{ github.event.client_payload.tag }}"
-          $version=$version.replace('v','')
-          echo "::set-output name=version::$version"
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # pin@v2.4.0
       - name: Update package source files
         run: .github\workflows\update-gardenlogin.ps1 ${{ github.event.client_payload.tag }} ${{ github.event.client_payload.windows_sha }} 
       - name: Choco pack
         uses: crazy-max/ghaction-chocolatey@87d06bbbd2cfb1835f1820042d356aef4875fb5f # pin@v1.6
         with:
-          args: pack gardenlogin\gardenlogin.nuspec --version=${{ steps.get_version.outputs.version }} -y --outdir gardenlogin
+          args: pack gardenlogin\gardenlogin.nuspec --version=${{ needs.package-push-common.outputs.version }} -y --outdir gardenlogin
       - name: Choco push
         uses: crazy-max/ghaction-chocolatey@87d06bbbd2cfb1835f1820042d356aef4875fb5f # pin@v1.6
         with:
-          args: push "gardenlogin\gardenlogin.${{ steps.get_version.outputs.version }}.nupkg" --source https://chocolatey.org -k ${{ secrets.CHOCOLATEY_API_KEY }}
+          args: push "gardenlogin\gardenlogin.${{ needs.package-push-common.outputs.version }}.nupkg" --source https://chocolatey.org -k ${{ secrets.CHOCOLATEY_API_KEY }}
       - name: Commit files
         run: |
           git config --local user.email "gardener.ci.user@gmail.com"
           git config --local user.name "gardener-robot-ci-1"
-          git add "gardenlogin\gardenlogin.${{ steps.get_version.outputs.version }}.nupkg"
+          git add "gardenlogin\gardenlogin.${{ needs.package-push-common.outputs.version }}.nupkg"
           git add "gardenlogin\tools\chocolateyinstall.ps1"
           git commit -m "Update gardenlogin"
       - name: Push changes
@@ -41,33 +47,24 @@ jobs:
   package-push-gardenctl-v2:
     if: github.event.client_payload.component == 'gardenctl-v2'
     runs-on: windows-latest
+    needs: package-push-common
     steps:
-      - name: Event Information
-        run: |
-          echo "Event '${{ github.event.action }}' payload '${{ github.event.client_payload.tag }}'"
-          echo "Windows gardenctl-v2 binary hash '${{ github.event.client_payload.windows_sha }}'"
-      - name: Get Version
-        id: get_version
-        run: |
-          $version="${{ github.event.client_payload.tag }}"
-          $version=$version.replace('v','')
-          echo "::set-output name=version::$version"
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # pin@v2.4.0
       - name: Update package source files
         run: .github\workflows\update-gardenctl-v2.ps1 ${{ github.event.client_payload.tag }} ${{ github.event.client_payload.windows_sha }} 
       - name: Choco pack
         uses: crazy-max/ghaction-chocolatey@87d06bbbd2cfb1835f1820042d356aef4875fb5f # pin@v1.6
         with:
-          args: pack gardenctl-v2\gardenctl-v2.nuspec --version=${{ steps.get_version.outputs.version }} -y --outdir gardenctl-v2
+          args: pack gardenctl-v2\gardenctl-v2.nuspec --version=${{ needs.package-push-common.outputs.version }} -y --outdir gardenctl-v2
       - name: Choco push
         uses: crazy-max/ghaction-chocolatey@87d06bbbd2cfb1835f1820042d356aef4875fb5f # pin@v1.6
         with:
-          args: push "gardenctl-v2\gardenctl-v2.${{ steps.get_version.outputs.version }}.nupkg" --source https://chocolatey.org -k ${{ secrets.CHOCOLATEY_API_KEY }}
+          args: push "gardenctl-v2\gardenctl-v2.${{ needs.package-push-common.outputs.version }}.nupkg" --source https://chocolatey.org -k ${{ secrets.CHOCOLATEY_API_KEY }}
       - name: Commit files
         run: |
           git config --local user.email "gardener.ci.user@gmail.com"
           git config --local user.name "gardener-robot-ci-1"
-          git add "gardenctl-v2\gardenctl-v2.${{ steps.get_version.outputs.version }}.nupkg"
+          git add "gardenctl-v2\gardenctl-v2.${{ needs.package-push-common.outputs.version }}.nupkg"
           git add "gardenctl-v2\tools\chocolateyinstall.ps1"
           git commit -m "Update gardenctl-v2"
       - name: Push changes

--- a/.github/workflows/update-gardenlogin.ps1
+++ b/.github/workflows/update-gardenlogin.ps1
@@ -21,4 +21,11 @@ Param(
   FileFullPath    = "`$toolsDir\gardenlogin.exe"
 }
 Get-ChocolateyWebFile @packageArgs
+Install-BinFile -Name "kubectl-gardenlogin" -Path "`$toolsDir\gardenlogin.exe"
+
 "@ > gardenlogin\tools\chocolateyinstall.ps1
+
+@"	
+Uninstall-BinFile -Name "kubectl-gardenlogin"
+"@ > gardenlogin\tools\chocolateyuninstall.ps1
+

--- a/gardenctl-v2/gardenctl-v2.nuspec
+++ b/gardenctl-v2/gardenctl-v2.nuspec
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   <metadata>
     <id>gardenctl-v2</id>
     <version>0.0.0</version>
+    <releaseNotes>https://github.com/gardener/gardenctl-v2/releases</releaseNotes>
     <packageSourceUrl>https://github.com/gardener/chocolatey-packages/tree/master/gardenctl-v2</packageSourceUrl>
     <title>gardenctl-v2 (Install)</title>
     <authors>SAP SE or an SAP affiliate company and Gardener contributors</authors>

--- a/gardenlogin/gardenlogin.nuspec
+++ b/gardenlogin/gardenlogin.nuspec
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   <metadata>
     <id>gardenlogin</id>
     <version>0.0.0</version>
+    <releaseNotes>https://github.com/gardener/gardenlogin/releases</releaseNotes>
     <packageSourceUrl>https://github.com/gardener/chocolatey-packages/tree/master/gardenlogin</packageSourceUrl>
     <title>gardenlogin (Install)</title>
     <authors>SAP SE or an SAP affiliate company and Gardener contributors</authors>


### PR DESCRIPTION
**What this PR does / why we need it**:
Added shim for kubectl-gardenlogin to generation script
Also moved common tasks into preparation job to minimize code duplication

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
