### PR TITLE
Rename binary to gardenctl

### DIFF
--- a/.github/workflows/update-gardenctl-v2.ps1
+++ b/.github/workflows/update-gardenctl-v2.ps1
@@ -18,7 +18,7 @@ Param(
   Url64bit        = `$url64
   ChecksumType64  = 'sha256'
   Checksum64      = "$checksum64"
-  FileFullPath    = "`$toolsDir\gardenctl-v2.exe"
+  FileFullPath    = "`$toolsDir\gardenctl.exe"
 }
 Get-ChocolateyWebFile @packageArgs
 "@ > gardenctl-v2\tools\chocolateyinstall.ps1

--- a/gardenctl-v2/tools/chocolateyinstall.ps1
+++ b/gardenctl-v2/tools/chocolateyinstall.ps1
@@ -7,6 +7,6 @@ $packageArgs = @{
   Url64bit        = $url64
   ChecksumType64  = 'sha256'
   Checksum64      = "81c8f4e43527fec0849a3dbea003d2a1fd429c1d3f345606fdaa9e42500c69db"
-  FileFullPath    = "$toolsDir\gardenctl-v2.exe"
+  FileFullPath    = "$toolsDir\gardenctl.exe"
 }
 Get-ChocolateyWebFile @packageArgs


### PR DESCRIPTION
**What this PR does / why we need it**:
The gardenctl-v2 binary should be named gardenctl, otherwise the target commands that can be copied from the dashboard won't work

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
