### PR TITLE
Add gardenlogin as dependency

### DIFF
--- a/gardenctl-v2/gardenctl-v2.nuspec
+++ b/gardenctl-v2/gardenctl-v2.nuspec
@@ -24,6 +24,9 @@ SPDX-License-Identifier: Apache-2.0
       `gardenctl` is a command-line client for administrative purposes for the Gardener.
       It facilitates the administration of one or many garden, seed and shoot clusters, e.g. to check for issues which occured in one of these clusters.
     </description>
+    <dependencies>
+      <dependency id="gardenlogin"/>
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `gardenlogin` as dependency to be installed with `gardenctl-v2`

**Which issue(s) this PR fixes**:
Fixes #12

**Special notes for your reviewer**:
I'm not aware on how to add post install notes with chocolatey

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
