### PR TITLE
Add `kubelogin` install hint for `gardenlogin`

### DIFF
--- a/gardenctl-v2/gardenctl-v2.nuspec
+++ b/gardenctl-v2/gardenctl-v2.nuspec
@@ -19,10 +19,15 @@ SPDX-License-Identifier: Apache-2.0
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/gardener/gardenctl-v2</projectSourceUrl>
     <tags>gardenctl-v2</tags>
-    <summary>gardenctl-v2 ist the revision of gardenctl, Gardener's command-line client</summary>
+    <summary>gardenctl-v2 is the revision of gardenctl, Gardener's command-line client</summary>
     <description>
-      `gardenctl` is a command-line client for administrative purposes for the Gardener.
-      It facilitates the administration of one or many garden, seed and shoot clusters, e.g. to check for issues which occured in one of these clusters.
+      gardenctl is a command-line client for administrative purposes for the Gardener.
+      It facilitates the administration of one or many garden, seed and shoot clusters.
+
+      HINT: Consider adding the gardenctl startup script to your shell profile.
+      It contains various tweaks, such as setting environment variables,
+      loading completions, and adding some helpful aliases or functions.
+      Run `gardenctl rc --help` for more information.
     </description>
     <dependencies>
       <dependency id="gardenlogin"/>

--- a/gardenlogin/gardenlogin.nuspec
+++ b/gardenlogin/gardenlogin.nuspec
@@ -24,6 +24,10 @@ SPDX-License-Identifier: Apache-2.0
       This tool allows users of Shoot clusters operated by [Gardener](https://gardener.cloud/) to access their clusters as cluster-admin using dynamically generated short-living credentials.
       `gardenlogin`s `get-client-certificate` command can be used as a `kubectl` [credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins). It fetches the `cluster-admin` credentials from the API introduced with [GEP-16](https://github.com/gardener/gardener/blob/master/docs/proposals/16-adminkubeconfig-subresource.md). See more details under [Authentication Flow](#authentication-flow) 
       With GEP-16, users are able to generate kubeconfigs for `Shoot` clusters with short-lived certificates, to access the cluster as `cluster-admin`.
+
+      HINT: If you are using an OIDC kubeconfig, you may need to install 'kubelogin'.
+      You can install it manually by running:
+        choco install kubelogin
     </description>
   </metadata>
   <files>

--- a/gardenlogin/gardenlogin.nuspec
+++ b/gardenlogin/gardenlogin.nuspec
@@ -21,9 +21,8 @@ SPDX-License-Identifier: Apache-2.0
     <tags>gardenlogin</tags>
     <summary>gardenlogin get-client-certificate command can be used as a kubectl credential plugin</summary>
     <description>
-      This tool allows users of Shoot clusters operated by [Gardener](https://gardener.cloud/) to access their clusters as cluster-admin using dynamically generated short-living credentials.
-      `gardenlogin`s `get-client-certificate` command can be used as a `kubectl` [credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins). It fetches the `cluster-admin` credentials from the API introduced with [GEP-16](https://github.com/gardener/gardener/blob/master/docs/proposals/16-adminkubeconfig-subresource.md). See more details under [Authentication Flow](#authentication-flow) 
-      With GEP-16, users are able to generate kubeconfigs for `Shoot` clusters with short-lived certificates, to access the cluster as `cluster-admin`.
+      This tool allows users of Shoot clusters operated by Gardener to access their clusters as cluster-admin using dynamically generated short-living credentials.
+      `gardenlogin`s `get-client-certificate` command can be used as a `kubectl` credential plugin.
 
       HINT: If you are using an OIDC kubeconfig, you may need to install 'kubelogin'.
       You can install it manually by running:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `kubelogin` install hint for `gardenlogin`.
In addition, it includes the hint to add the gardenctl startup script to the users shell profile.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/gardenlogin/issues/142

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
