### PR TITLE
Push diki packages

### DIFF
--- a/.github/workflows/choco-package.yml
+++ b/.github/workflows/choco-package.yml
@@ -73,3 +73,31 @@ jobs:
           delete-branch: true
           title: update ${{ github.event.client_payload.component }} to ${{ github.event.client_payload.tag }}
           body: This PR adds Chocolatey package for version ${{ github.event.client_payload.tag }} and updates package sources
+  package-push-diki:
+    if: github.event.client_payload.component == 'diki'
+    runs-on: windows-latest
+    needs: package-push-common
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - name: Update package source files
+        run: .github\workflows\update-diki.ps1 ${{ github.event.client_payload.tag }} ${{ github.event.client_payload.windows_sha }}
+      - name: Choco pack
+        uses: crazy-max/ghaction-chocolatey@2ae99523e93879734d432250f87e2c45c379cd60 # pin@v3.2.0
+        with:
+          args: pack diki\diki.nuspec --version=${{ needs.package-push-common.outputs.cleaned_version }} -y --outdir diki
+      - name: Choco push
+        if: ${{ vars.SKIP_CHOCO_PUSH_DIKI != 'true' }}
+        uses: crazy-max/ghaction-chocolatey@2ae99523e93879734d432250f87e2c45c379cd60 # pin@v3.2.0
+        with:
+          args: push "diki\diki.${{ needs.package-push-common.outputs.cleaned_version }}.nupkg" --source https://chocolatey.org -k ${{ secrets.CHOCOLATEY_API_KEY }}
+      - name: Choco push - print skip info
+        if: ${{ vars.SKIP_CHOCO_PUSH_DIKI == 'true' }}
+        run: echo "Choco push step was skipped for package-push-diki."
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # pin@v7.0.6
+        with:
+          add-paths: diki\diki.${{ needs.package-push-common.outputs.cleaned_version }}.nupkg,diki\tools\chocolateyinstall.ps1
+          branch: update_${{ github.event.client_payload.component }}_${{ github.event.client_payload.tag }}
+          delete-branch: true
+          title: update ${{ github.event.client_payload.component }} to ${{ github.event.client_payload.tag }}
+          body: This PR adds Chocolatey package for version ${{ github.event.client_payload.tag }} and updates package sources

--- a/.github/workflows/update-diki.ps1
+++ b/.github/workflows/update-diki.ps1
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+Param(
+  [Parameter(Mandatory=$true)]
+  [string]$version,
+  [Parameter(Mandatory=$true)]
+  [string]$checksum64
+)
+
+@"	
+`$ErrorActionPreference = 'Stop'
+`$url64      = "https://github.com/gardener/diki/releases/download/$version/diki-windows-amd64"
+`$toolsDir   = "`$(Split-Path -parent `$MyInvocation.MyCommand.Definition)"
+
+`$packageArgs = @{
+  PackageName     = `$env:ChocolateyPackageName
+  Url64bit        = `$url64
+  ChecksumType64  = 'sha256'
+  Checksum64      = "$checksum64"
+  FileFullPath    = "`$toolsDir\diki.exe"
+}
+Get-ChocolateyWebFile @packageArgs
+"@ > diki\tools\chocolateyinstall.ps1

--- a/diki/diki.nuspec
+++ b/diki/diki.nuspec
@@ -20,11 +20,10 @@
     <tags>diki</tags>
     <summary>diki is a compliance checker that aims to enhance the security posture of your Kubernetes clusters</summary>
     <description>
-      `diki` is a command-line tool for running compliance checks.
+      diki is a command-line tool for running compliance checks.
       
       Hints:
-      Run `diki view provider` to view supported providers and rulesets.
-      Run `diki --help` for more information.
+      Run `diki --help` for more information or find out more at https://github.com/gardener/diki.
     </description>
   </metadata>
   <files>

--- a/diki/diki.nuspec
+++ b/diki/diki.nuspec
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+ <!--
+ SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+ 
+ SPDX-License-Identifier: Apache-2.0
+ -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>diki</id>
+    <version>0.0.0</version>
+    <packageSourceUrl>https://github.com/gardener/chocolatey-packages/tree/master/diki</packageSourceUrl>
+    <title>diki (Install)</title>
+    <authors>SAP SE or an SAP affiliate company and Gardener contributors</authors>
+    <projectUrl>https://gardener.cloud</projectUrl>
+    <iconUrl>https://github.com/gardener/gardener/blob/master/logo/gardener-large.png</iconUrl>
+    <copyright>2025 SAP SE</copyright>
+    <licenseUrl>https://github.com/gardener/diki/blob/master/LICENSES/Apache-2.0.txt</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/gardener/diki</projectSourceUrl>
+    <tags>diki</tags>
+    <summary>diki is a compliance checker that aims to enhance the security posture of your Kubernetes clusters</summary>
+    <description>
+      `diki` is a command-line tool for running compliance checks.
+      
+      Hints:
+      Run `diki view provider` to view supported providers and rulesets.
+      Run `diki --help` for more information.
+    </description>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/diki/tools/chocolateyinstall.ps1
+++ b/diki/tools/chocolateyinstall.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = 'Stop'
+$url64      = "https://github.com/gardener/diki/releases/download/v0.14.0/diki-windows-amd64"
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$packageArgs = @{
+  PackageName     = $env:ChocolateyPackageName
+  Url64bit        = $url64
+  ChecksumType64  = 'sha256'
+  Checksum64      = "7ee1f74728c2cba035710c48919f411875cacd239f811f93b06d0a57fc9fe853"
+  FileFullPath    = "$toolsDir\diki.exe"
+}
+Get-ChocolateyWebFile @packageArgs


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new job to push diki packages to Chocolatey in the `Remote Dispatch Action` workflow which will be triggered on a new release of diki https://github.com/gardener/diki/pull/449

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
