### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/choco-package.yml
+++ b/.github/workflows/choco-package.yml
@@ -2,7 +2,6 @@ name: Remote Dispatch Action
 on: [repository_dispatch]
 permissions:
   contents: write
-  packages: write
 jobs:
   package-push-common:
     runs-on: windows-latest

--- a/.github/workflows/choco-package.yml
+++ b/.github/workflows/choco-package.yml
@@ -1,5 +1,8 @@
 name: Remote Dispatch Action
 on: [repository_dispatch]
+permissions:
+  contents: write
+  packages: write
 jobs:
   package-push-common:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/chocolatey-packages/security/code-scanning/1](https://github.com/gardener/chocolatey-packages/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal permissions required for the workflow. Based on the operations performed in the workflow:
- `contents: read` is required to read repository contents.
- `contents: write` is required for the `create-pull-request` action to create and update pull requests.

The `permissions` block will be added at the top level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
