### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -2,6 +2,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/chocolatey-packages/security/code-scanning/2](https://github.com/gardener/chocolatey-packages/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow is performing a REUSE compliance check, it likely only needs read access to the repository contents. We will set `contents: read` as the minimal required permission. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
