### PR TITLE
Update OWNERS_ALIASES to replace klocke-io with AleksandarSavchev

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,8 +4,8 @@ aliases:
   chocolatey-packages-reviewers:
   - petersutter
   - grolu
-  - klocke-io
+  - AleksandarSavchev
   chocolatey-packages-approvers:
   - petersutter
   - grolu
-  - klocke-io
+  - AleksandarSavchev


### PR DESCRIPTION
Removed klocke-io as he will no longer review PRs here. Added Aleksandar as he owns the diki package.

<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
