### PR TITLE
ci: fix create-pr runner and use ci- branch prefix

### DIFF
--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -256,7 +256,7 @@ jobs:
             git "$@"
           }
 
-          branch="update_${COMPONENT}_${FULL_TAG}"
+          branch="ci-update-${COMPONENT}-${FULL_TAG}"
           git switch -c "$branch"
 
           git add "${PKG_DIR}/${PKG_NAME}.${NUM_VERSION}.nupkg"

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -198,7 +198,7 @@ jobs:
 ##############################################################################
   create-pr:
     needs: [resolve-inputs, package]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
- Move the `create-pr` job in `remote-dispatch.yaml` from `windows-latest` to `ubuntu-latest`. The `gardener/cc-utils` `github-auth@v1` action imports PyYAML in its `preprocess.py`, but does not install it. PyYAML is preinstalled on ubuntu runners and missing on windows-latest, so the step failed with `ModuleNotFoundError: No module named 'yaml'`. Only the `package` and `publish-chocolatey` jobs actually need windows for `choco`; `create-pr` only runs `git`/`gh`, so this fix removes the failure and reduces unnecessary windows runner usage at the same time.
- Use a `ci-` prefix for package-update branches created by the workflow. The repository branch ruleset rejects `update_*` names; `ci-update-<component>-<tag>` matches the allow-list so pushes succeed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other dependency
NONE
```