### PR TITLE
ci: add area and kind labels to formula update PRs

### DIFF
--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -272,4 +272,4 @@ jobs:
             --head "$branch" \
             --base "$DEFAULT_BRANCH" \
             --title "update $COMPONENT to $FULL_TAG" \
-            --body  "Updates Chocolatey package for **$COMPONENT** ($FULL_TAG)."
+            --body "$(printf 'Updates Chocolatey package for **%s** (%s).\n\n/area ops-productivity\n/kind enhancement' "$COMPONENT" "$FULL_TAG")"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Appends `/area ops-productivity` and `/kind enhancement` slash commands to the body of PRs created by the formula update workflow. The labeling bot picks up these commands and applies the corresponding categorization labels automatically, matching the convention used elsewhere in Gardener repos.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**: